### PR TITLE
fix(ERR_UNKNOWN: Unable to retrieve simulator list)

### DIFF
--- a/src/ios/utils/simulator.ts
+++ b/src/ios/utils/simulator.ts
@@ -10,6 +10,7 @@ const debug = Debug('native-run:ios:utils:simulator');
 
 export interface Simulator {
   availability: '(available)' | '(unavailable)';
+  isAvailable: boolean;
   name: string; // "iPhone 5";
   state: string; // "Shutdown"
   udid: string;
@@ -49,7 +50,7 @@ export async function getSimulators() {
     return output.runtimes
       .filter(runtime => runtime.name.indexOf('watch') === -1 && runtime.name.indexOf('tv') === -1)
       .map(runtime => output.devices[runtime.identifier]
-        .filter(device => !device.availability.includes('unavailable'))
+        .filter(device => device.isAvailable)
         .map(device => ({ ...device, runtime }))
       )
       .reduce((prev, next) => prev.concat(next)) // flatten


### PR DESCRIPTION
When execute `ionic cordova emulate ios` I get error:

```
** BUILD SUCCEEDED **

> native-run ios --app platforms/ios/build/emulator/Delos.app
ERR_UNKNOWN: Unable to retrieve simulator list
[ERROR] An error occurred while running subprocess native-run.
        
        native-run ios --app platforms/ios/build/emulator/Delos.app exited with exit
        code 1.
```

The JSON output of `xcrun simctl list --json` don't have "availability" in "runtimes" anymore, inplace have "isAvailable".

I'm not sure if this happened after instal Xcode 11 beta 1 with Xcode 10 together... My `xcrun` currently is `43.1`.
 
This changes fix the issue.