### PR TITLE
fix: add missing signal-exit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "elementtree": "^0.1.7",
     "ini": "^1.3.5",
     "plist": "^3.0.1",
+    "signal-exit": "^3.0.3",
     "split2": "^3.1.0",
     "through2": "^4.0.2",
     "tslib": "^2.0.1",


### PR DESCRIPTION
Fix related with: https://github.com/ionic-team/native-run/issues/60#issuecomment-700426184