### PR TITLE
fix: don't print ADB unresponsive error to stdout

### DIFF
--- a/src/android/utils/adb.ts
+++ b/src/android/utils/adb.ts
@@ -468,7 +468,7 @@ export async function execAdb(
   let timer: NodeJS.Timer | undefined;
 
   const retry = async () => {
-    process.stdout.write(
+    debug(
       `ADB is unresponsive after ${options.timeout}ms, killing server and retrying...\n`,
     );
     debug(

--- a/src/android/utils/adb.ts
+++ b/src/android/utils/adb.ts
@@ -468,7 +468,7 @@ export async function execAdb(
   let timer: NodeJS.Timer | undefined;
 
   const retry = async () => {
-    debug(
+    process.stderr.write(
       `ADB is unresponsive after ${options.timeout}ms, killing server and retrying...\n`,
     );
     debug(


### PR DESCRIPTION
While testing `capacitor run` command I got `Unexpected token A in JSON at position 0`.
It's caused because `execAdb` is printing the `ADB is unresponsive after 5000ms, killing server and retrying...` message to stdout, which makes it not proper JSON.
I think it should not be printed to stdout, but instead be directed to debug as the other error messages of `execAdb`.