### PR TITLE
fix: don't print retry message for --json

### DIFF
--- a/src/android/utils/adb.ts
+++ b/src/android/utils/adb.ts
@@ -468,9 +468,13 @@ export async function execAdb(
   let timer: NodeJS.Timer | undefined;
 
   const retry = async () => {
-    process.stderr.write(
-      `ADB is unresponsive after ${options.timeout}ms, killing server and retrying...\n`,
-    );
+    const msg = `ADBs is unresponsive after ${options.timeout}ms, killing server and retrying...\n`;
+    if (process.argv.includes('--json')) {
+      debug(msg);
+    } else {
+      process.stderr.write(msg);
+    }
+
     debug(
       'ADB timeout of %O reached, killing server and retrying...',
       options.timeout,


### PR DESCRIPTION
When native-run tries to retry it prints a retry message that is put into the returned message and makes it invalid json

This checks the param and pipe te message into the debug instead when --json is passed