### PR TITLE
fix: throw iOS errors that are not DeviceLocked

### DIFF
--- a/src/ios/run.ts
+++ b/src/ios/run.ts
@@ -82,7 +82,7 @@ async function runIpaOrAppFileOnInterval(config: IOSRunConfig): Promise<void> {
   const run = async () => {
     try {
       await runIpaOrAppFile(config);
-    } catch (err) {
+    } catch (err: any) {
       if (
         err instanceof IOSLibError &&
         err.code == 'DeviceLocked' &&
@@ -90,7 +90,7 @@ async function runIpaOrAppFileOnInterval(config: IOSRunConfig): Promise<void> {
       ) {
         await retry();
       } else {
-        if (maxRetryCount >= retryCount) {
+        if (retryCount >= maxRetryCount) {
           error = new IOSRunException(
             `Device still locked after 1 minute. Aborting.`,
             ERR_DEVICE_LOCKED,


### PR DESCRIPTION
Closes https://github.com/ionic-team/native-run/issues/199.