### PR TITLE
fix: Throw ERR_UNSUPPORTED_API_LEVEL

### DIFF
--- a/src/android/utils/avd.ts
+++ b/src/android/utils/avd.ts
@@ -218,7 +218,9 @@ export async function getDefaultAVDSchematic(sdk: SDK): Promise<AVDSchematic> {
     }
   }
   if (errors.length > 0) {
-    const unsupportedError = errors.find(e => e.code === ERR_UNSUPPORTED_API_LEVEL);
+    const unsupportedError = errors.find(
+      e => e.code === ERR_UNSUPPORTED_API_LEVEL,
+    );
     if (unsupportedError) {
       throw unsupportedError;
     }


### PR DESCRIPTION
At the moment, if there is an ERR_UNSUPPORTED_API_LEVEL, it's missed and thrown as a generic ERR_UNSUITABLE_API_INSTALLATION, this PR checks if an ERR_UNSUPPORTED_API_LEVEL error was thrown and if it was, re throw it instead of the generic ERR_UNSUITABLE_API_INSTALLATION.

Also adds a bit more information about the ERR_UNSUITABLE_API_INSTALLATION

closes https://github.com/ionic-team/native-run/issues/195