### PR TITLE
fix(android): Use arm64 architecture on emulator creation from M1

### DIFF
--- a/src/android/utils/avd.ts
+++ b/src/android/utils/avd.ts
@@ -1,5 +1,6 @@
 import { copy, mkdirp, readdir, statSafe } from '@ionic/utils-fs';
 import * as Debug from 'debug';
+import * as os from 'os';
 import * as pathlib from 'path';
 
 import { ASSETS_PATH } from '../../constants';
@@ -319,7 +320,7 @@ export async function createAVDSchematic(
   );
   const sysdir = pathlib.relative(sdk.root, sysimage.location);
   const [, , tagid] = sysimage.path.split(';');
-
+  const arch = os.arch() === 'arm64' ? 'arm64' : partialSchematic.configini['abi.type'];
   const schematic: AVDSchematic = {
     id: partialSchematic.id,
     ini: sort({
@@ -329,6 +330,8 @@ export async function createAVDSchematic(
     }),
     configini: sort({
       ...partialSchematic.configini,
+      'abi.type': arch,
+      'hw.cpu.arch': arch,
       'skin.path': skinpath,
       'image.sysdir.1': sysdir,
       'tag.id': tagid,

--- a/src/android/utils/avd.ts
+++ b/src/android/utils/avd.ts
@@ -320,7 +320,8 @@ export async function createAVDSchematic(
   );
   const sysdir = pathlib.relative(sdk.root, sysimage.location);
   const [, , tagid] = sysimage.path.split(';');
-  const arch = os.arch() === 'arm64' ? 'arm64' : partialSchematic.configini['abi.type'];
+  const arch =
+    os.arch() === 'arm64' ? 'arm64' : partialSchematic.configini['abi.type'];
   const schematic: AVDSchematic = {
     id: partialSchematic.id,
     ini: sort({


### PR DESCRIPTION
When there is no emulator for the SDK, native-run will try to create a new one, but on M1 macs it fails to create new emulators because the emulator files we provide have the architecture hardcoded to x86.
This patch will check the machine architecture and if it's arm64 it will overwrite the x86 values with arm64, fixing the emulator creation.