### PR TITLE
fix: NodeJS 18 compat

### DIFF
--- a/src/ios/lib/client/lockdownd.ts
+++ b/src/ios/lib/client/lockdownd.ts
@@ -139,6 +139,7 @@ export class LockdowndClient extends ServiceClient<LockdownProtocolClient> {
           this.protocolClient.socket,
           {
             secureContext: tls.createSecureContext({
+              secureProtocol: 'TLSv1_2_method',
               cert: pairRecord.RootCertificate,
               key: pairRecord.RootPrivateKey,
             }),

--- a/src/ios/lib/client/lockdownd.ts
+++ b/src/ios/lib/client/lockdownd.ts
@@ -139,7 +139,6 @@ export class LockdowndClient extends ServiceClient<LockdownProtocolClient> {
           this.protocolClient.socket,
           {
             secureContext: tls.createSecureContext({
-              secureProtocol: 'TLSv1_method',
               cert: pairRecord.RootCertificate,
               key: pairRecord.RootPrivateKey,
             }),

--- a/src/ios/lib/manager.ts
+++ b/src/ios/lib/manager.ts
@@ -110,6 +110,7 @@ export class ClientManager {
       const tlsOptions: tls.ConnectionOptions = {
         rejectUnauthorized: false,
         secureContext: tls.createSecureContext({
+          secureProtocol: 'TLSv1_2_method',
           cert: this.pairRecord.RootCertificate,
           key: this.pairRecord.RootPrivateKey,
         }),

--- a/src/ios/lib/manager.ts
+++ b/src/ios/lib/manager.ts
@@ -110,7 +110,6 @@ export class ClientManager {
       const tlsOptions: tls.ConnectionOptions = {
         rejectUnauthorized: false,
         secureContext: tls.createSecureContext({
-          secureProtocol: 'TLSv1_method',
           cert: this.pairRecord.RootCertificate,
           key: this.pairRecord.RootPrivateKey,
         }),

--- a/src/ios/lib/protocol/protocol.ts
+++ b/src/ios/lib/protocol/protocol.ts
@@ -127,6 +127,7 @@ export abstract class ProtocolClient<MessageType = any> {
           }
         },
       );
+      this.socket.on('error', err => {throw err});
       this.socket.on('data', reader.onData);
       this.writer.write(this.socket, msg);
     });

--- a/src/ios/lib/protocol/protocol.ts
+++ b/src/ios/lib/protocol/protocol.ts
@@ -127,7 +127,9 @@ export abstract class ProtocolClient<MessageType = any> {
           }
         },
       );
-      this.socket.on('error', err => {throw err});
+      this.socket.on('error', err => {
+        throw err;
+      });
       this.socket.on('data', reader.onData);
       this.writer.write(this.socket, msg);
     });


### PR DESCRIPTION
The iOS deployment was silently failing with NodeJS 18.

The `src/ios/lib/protocol/protocol.ts:sendMessage(msg, callback)` was simply not resolving due to an error while writing on the socket. 

After adding
```
this.socket.on('error', err => {throw err});
```
I got this logged
```
 Error: write EPROTO C0947D4CF87F0000:error:0A0C0103:SSL routines:tls_process_key_exchange:internal
        error:../deps/openssl/openssl/ssl/statem/statem_clnt.c:2262:
        
        at WriteWrap.onWriteComplete [as oncomplete] (node:internal/stream_base_commons:94:16) {
            errno: -100,
            code: 'EPROTO',
            syscall: 'write'
        }

```

So I bumped the `secureProtocol` TLS to v1.2 and it fixes the error and works fine with nodejs 18, 16 and 12