### PR TITLE
bugfix issues #321 and #324

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "native-run": "bin/native-run"
   },
   "scripts": {
-    "clean": "rm -rf dist",
+    "clean": "npx rimraf dist",
     "build": "npm run clean && tsc",
     "watch": "tsc -w",
     "test": "jest --maxWorkers=4",
@@ -63,6 +63,7 @@
     "husky": "^5.0.4",
     "jest": "^26.4.2",
     "prettier": "^2.2.1",
+    "rimraf": "^5.0.1",
     "semantic-release": "^19.0.5",
     "ts-jest": "^26.3.0",
     "typescript": "~4.1.2"

--- a/src/android/utils/sdk/__tests__/index.ts
+++ b/src/android/utils/sdk/__tests__/index.ts
@@ -126,4 +126,55 @@ describe('android/utils/sdk', () => {
       expect(mockIsDir).toHaveBeenCalledWith('/home/me/Library/Android/sdk');
     });
   });
+
+  describe('resolveEmulatorHome', () => {
+    beforeEach(async () => {
+      sdkUtils = await import('../');
+    });
+
+    it('should resolve with ANDROID_EMULATOR_HOME if in environment', async () => {
+      mockIsDir.mockResolvedValueOnce(true);
+      Object.defineProperty(process, 'env', {
+        value: {
+          ANDROID_EMULATOR_HOME: '/some/dir',
+          ANDROID_USER_HOME: '/some/other/dir',
+        },
+      });
+      await expect(sdkUtils.resolveEmulatorHome()).resolves.toEqual('/some/dir');
+      expect(mockIsDir).toHaveBeenCalledTimes(1);
+      expect(mockIsDir).toHaveBeenCalledWith('/some/dir');
+    });
+
+    it('should resolve with ANDROID_USER_HOME when ANDROID_EMULATOR_HOME is absent', async () => {
+      mockIsDir.mockResolvedValueOnce(true);
+      Object.defineProperty(process, 'env', {
+        value: {
+          ANDROID_USER_HOME: '/some/dir/.android',
+        },
+      });
+      await expect(sdkUtils.resolveEmulatorHome()).resolves.toEqual('/some/dir/.android');
+      expect(mockIsDir).toHaveBeenCalledTimes(1);
+      expect(mockIsDir).toHaveBeenCalledWith('/some/dir/.android');
+    });
+
+    it('should resolve with ANDROID_SDK_HOME/.android when ANDROID_EMULATOR_HOME and ANDROID_USER_HOME are absent', async () => {
+      mockIsDir.mockResolvedValueOnce(true);
+      Object.defineProperty(process, 'env', {
+        value: {
+          ANDROID_SDK_HOME: '/some/dir',
+        },
+      });
+      await expect(sdkUtils.resolveEmulatorHome()).resolves.toEqual('/some/dir/.android');
+      expect(mockIsDir).toHaveBeenCalledTimes(1);
+      expect(mockIsDir).toHaveBeenCalledWith('/some/dir');
+    })
+
+    it('should resolve with HOME/.android when ANDROID_EMULATOR_HOME, ANDROID_USER_HOME, ANDROID_SDK_HOME all are absent', async () => {
+      mockIsDir.mockResolvedValueOnce(true);
+      await expect(sdkUtils.resolveEmulatorHome()).resolves.toEqual('/home/me/.android');
+      expect(mockIsDir).toHaveBeenCalledTimes(1);
+      expect(mockIsDir).toHaveBeenCalledWith('/home/me/.android');
+    })
+
+  });
 });


### PR DESCRIPTION
- make Android emulator home directory resolving consistent with AVDManager
- when calling `native-run android --list`, a default AVD will be created if not found, make it use the right system image
