### PR TITLE
chore(ci): Replace GH_TOKEN with IONITRON_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - run: npm install
       - run: npm run publish:ci
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.IONITRON_GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: Ionitron
           GIT_AUTHOR_EMAIL: hi@ionicframework.com
           GIT_COMMITTER_NAME: Ionitron


### PR DESCRIPTION
latest publish failed to create the github release because of the token was invalid or didn't have the proper permissions, so I'm replacing it with the global IONITRON_GITHUB_TOKEN