### PR TITLE
refactor: remove invalid xcode check

### DIFF
--- a/src/ios/utils/simulator.ts
+++ b/src/ios/utils/simulator.ts
@@ -5,7 +5,7 @@ import { Exception } from '../../errors';
 import { log } from '../../utils/log';
 import { onBeforeExit } from '../../utils/process';
 
-import { getXCodePath, getXcodeVersionInfo } from './xcode';
+import { getXCodePath } from './xcode';
 
 const debug = Debug('native-run:ios:utils:simulator');
 
@@ -49,11 +49,6 @@ export async function getSimulators(): Promise<SimulatorResult[]> {
   });
   if (simctl.status) {
     throw new Exception(`Unable to retrieve simulator list: ${simctl.stderr}`);
-  }
-
-  const [xcodeVersion] = getXcodeVersionInfo();
-  if (Number(xcodeVersion) < 10) {
-    throw new Exception('native-run only supports Xcode 10 and later');
   }
 
   try {


### PR DESCRIPTION
If the Xcode version is major.minor.patch, the `Number(xcodeVersion)` is returning `NaN`, so the `< 10` check is always false.
I could fix the version check, but since Xcode 10 is ancient, I think it's better to just remove the code as it's not doing anything.