### PR TITLE
chore: update typescript

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
       diagnostics: {
         // warnOnly: true,
       },
-      tsConfig: {
+      tsconfig: {
         types: [
           "node",
           "jest",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@ionic/prettier-config": "^4.0.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "@types/babel__traverse": "7.17.1",
+    "@types/babel__traverse": "7.20.3",
     "@types/debug": "^4.1.10",
     "@types/elementtree": "^0.1.3",
     "@types/ini": "^1.3.32",
@@ -64,7 +64,7 @@
     "prettier": "^3.0.3",
     "semantic-release": "^19.0.5",
     "ts-jest": "^26.3.0",
-    "typescript": "~4.1.2"
+    "typescript": "~4.9.5"
   },
   "prettier": "@ionic/prettier-config",
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "@ionic/prettier-config": "^4.0.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "@types/babel__traverse": "7.20.3",
     "@types/debug": "^4.1.10",
     "@types/elementtree": "^0.1.3",
     "@types/ini": "^1.3.32",

--- a/src/android/list.ts
+++ b/src/android/list.ts
@@ -17,7 +17,7 @@ export async function list(args: readonly string[]): Promise<Targets> {
     (async () => {
       try {
         return await getDeviceTargets(sdk);
-      } catch (e) {
+      } catch (e: any) {
         errors.push(e);
         return [];
       }
@@ -25,7 +25,7 @@ export async function list(args: readonly string[]): Promise<Targets> {
     (async () => {
       try {
         return await getVirtualTargets(sdk);
-      } catch (e) {
+      } catch (e: any) {
         errors.push(e);
         return [];
       }

--- a/src/android/utils/sdk/index.ts
+++ b/src/android/utils/sdk/index.ts
@@ -128,7 +128,7 @@ export async function getSDKPackage(location: string): Promise<SDKPackage> {
         name,
         apiLevel,
       };
-    } catch (e) {
+    } catch (e: any) {
       debug('Encountered error with %s: %O', packageXmlPath, e);
 
       if (e.code === 'ENOENT') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export async function run(): Promise<void> {
 
       throw new CLIException(`Unsupported platform: "${platform}"`, ERR_BAD_INPUT);
     }
-  } catch (e) {
+  } catch (e: any) {
     debug('Caught fatal error: %O', e);
     process.exitCode = e instanceof Exception ? e.exitCode : ExitCode.GENERAL;
     process.stdout.write(serializeError(e));

--- a/src/ios/lib/protocol/gdb.ts
+++ b/src/ios/lib/protocol/gdb.ts
@@ -53,7 +53,7 @@ export class GDBProtocolReader extends ProtocolReader {
           this.onData();
         }
       }
-    } catch (err) {
+    } catch (err: any) {
       this.callback(null, err);
     }
   }

--- a/src/ios/lib/protocol/protocol.ts
+++ b/src/ios/lib/protocol/protocol.ts
@@ -67,7 +67,7 @@ export abstract class ProtocolReader {
           this.onData();
         }
       }
-    } catch (err) {
+    } catch (err: any) {
       this.callback(null, err);
     }
   }

--- a/src/ios/list.ts
+++ b/src/ios/list.ts
@@ -19,7 +19,7 @@ export async function list(args: readonly string[]): Promise<Targets> {
       try {
         const devices = await getConnectedDevices();
         return devices.map(deviceToTarget);
-      } catch (e) {
+      } catch (e: any) {
         errors.push(e);
         return [];
       }
@@ -28,7 +28,7 @@ export async function list(args: readonly string[]): Promise<Targets> {
       try {
         const simulators = await getSimulators();
         return simulators.map(simulatorToTarget);
-      } catch (e) {
+      } catch (e: any) {
         errors.push(e);
         return [];
       }

--- a/src/ios/utils/simulator.ts
+++ b/src/ios/utils/simulator.ts
@@ -62,7 +62,7 @@ export async function getSimulators(): Promise<SimulatorResult[]> {
       )
       .reduce((prev, next) => prev.concat(next)) // flatten
       .sort((a, b) => (a.name < b.name ? -1 : 1));
-  } catch (err) {
+  } catch (err: any) {
     throw new Exception(`Unable to retrieve simulator list: ${err.message}`);
   }
 }


### PR DESCRIPTION
update typescript to latest 4.x
remove `@types/babel__traverse` since it's no longer needed to pin that version after the typescript update.