### PR TITLE
fix: paths contain non-ascii characters cause error

### DIFF
--- a/src/ios/lib/client/afc.ts
+++ b/src/ios/lib/client/afc.ts
@@ -52,7 +52,7 @@ export class AFCClient extends ServiceClient<AFCProtocolClient> {
   async openFile(path: string): Promise<Buffer> {
     debug(`openFile: ${path}`);
     // mode + path + null terminator
-    const data = Buffer.alloc(8 + path.length + 1);
+    const data = Buffer.alloc(8 + Buffer.byteLength(path) + 1);
     // write mode
     data.writeUInt32LE(AFC_FILE_OPEN_FLAGS.WRONLY, 0);
     // then path to file
@@ -176,7 +176,7 @@ export class AFCClient extends ServiceClient<AFCProtocolClient> {
 }
 
 function toCString(s: string) {
-  const buf = Buffer.alloc(s.length + 1);
+  const buf = Buffer.alloc(Buffer.byteLength(s) + 1);
   const len = buf.write(s);
   buf.writeUInt8(0, len);
   return buf;


### PR DESCRIPTION
fixes #65 

This is caused by filenames with non-ascii characters.

As an example add [this file](https://github.com/dtarnawsky/dust/blob/main/src/assets/ttitd-2023/images/ac-%C2%A1axolotl!.webp) to your assets of your app then call `npx cap run ios`.
