### PR TITLE
fix: parse adb devices with trailing CR

### DIFF
--- a/src/android/utils/adb.ts
+++ b/src/android/utils/adb.ts
@@ -289,7 +289,7 @@ export function parseAdbDevices(output: string): Device[] {
 
   for (const line of lines) {
     if (line && !line.startsWith('List')) {
-      const m = line.match(re);
+      const m = line.replace(/\r$/, '').match(re);
 
       if (m) {
         const [, serial, state, description] = m;


### PR DESCRIPTION
Closes #229

Fixes the error "No devices or emulators found" when running `ionic cap run android` on WSL.

Fixes `native-run:android:utils:adb:parseAdbDevices adb devices output line does not match expected regex: 'emulator-5554          device product:sdk_gphone64_x86_64 model:sdk_gphone64_x86_64 device:emu64xa transport_id:1\r' +0ms`

I implemented the issue author's suggested fix, and tested it. It allowed me to run `ionic cap run android`, including with live reload, on WSL.