### PR TITLE
feat: add ADB timeout option passed to startActivity function

### DIFF
--- a/src/android/help.ts
+++ b/src/android/help.ts
@@ -28,6 +28,8 @@ const help = `
     --target <id> ........... Use a specific target
     --connect ............... Tie process to app process
     --forward <port:port> ... Forward a port from device to host
+    --timeout <timeout> ..... ADB timeout in miliseconds
+                              Default is 5000
 `;
 
 export async function run(args: readonly string[]): Promise<void> {

--- a/src/android/run.ts
+++ b/src/android/run.ts
@@ -36,6 +36,7 @@ export async function run(args: readonly string[]): Promise<void> {
   const sdk = await getSDK();
   const apkPath = getOptionValue(args, '--app');
   const forwardedPorts = getOptionValues(args, '--forward');
+  const timeout = Number.parseFloat(getOptionValue(args, '--timeout', '5000'));
 
   const ports: Ports[] = [];
 
@@ -74,7 +75,7 @@ export async function run(args: readonly string[]): Promise<void> {
   await installApkToDevice(sdk, device, apkPath, appId);
 
   log(`Starting application activity ${appId}/${activityName}...\n`);
-  await startActivity(sdk, device, appId, activityName);
+  await startActivity(sdk, device, appId, activityName, timeout);
 
   log(`Run Successful\n`);
 

--- a/src/android/utils/adb.ts
+++ b/src/android/utils/adb.ts
@@ -269,12 +269,13 @@ export async function startActivity(
   device: Device,
   packageName: string,
   activityName: string,
+  timeout: number,
 ): Promise<void> {
   const debug = Debug(`${modulePrefix}:${startActivity.name}`);
   const args = ['-s', device.serial, 'shell', 'am', 'start', '-W', '-n', `${packageName}/${activityName}`];
 
   debug('Invoking adb with args: %O', args);
-  await execAdb(sdk, args, { timeout: 5000 });
+  await execAdb(sdk, args, { timeout: timeout });
 }
 
 export function parseAdbDevices(output: string): Device[] {


### PR DESCRIPTION
Fixes #259

Usage:

```
native-run android --app <path> --target <id> --timeout 10000
```

Timeout is only effective for `startActivity` function.

Other ADB commands should not require timeouts longer than the default `5000`