### PR TITLE
fix: increase timeout for adb startActivity command to 15000ms

### DIFF
--- a/src/android/utils/adb.ts
+++ b/src/android/utils/adb.ts
@@ -274,7 +274,9 @@ export async function startActivity(
   const args = ['-s', device.serial, 'shell', 'am', 'start', '-W', '-n', `${packageName}/${activityName}`];
 
   debug('Invoking adb with args: %O', args);
-  await execAdb(sdk, args, { timeout: 5000 });
+
+  // This particular ADB command may take a long time to execute
+  await execAdb(sdk, args, { timeout: 15000 });
 }
 
 export function parseAdbDevices(output: string): Device[] {


### PR DESCRIPTION
Fixes: #259

Supersedes #392 

I've decided to increase timeout for this particular command because it's the only one that's likely to time out.
I chose 15s because it works for my case.