### PR TITLE
chore: remove npm run setup from contributing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,10 @@
 
 Pull requests are welcome!
 
-To begin, clone the repo, then install dependencies and setup the project.
+To begin, clone the repo and install dependencies.
 
 ```
 npm install
-npm run setup
 ```
 
 The source code is written in TypeScript. Spin up the compiler to watch for source changes:


### PR DESCRIPTION
It was used by husky and removed in #355