### PR TITLE
fix: Support wireless iOS devices

### DIFF
--- a/src/ios/utils/device.ts
+++ b/src/ios/utils/device.ts
@@ -22,6 +22,14 @@ export async function getConnectedDevices() {
       const socket = await new UsbmuxdClient(UsbmuxdClient.connectUsbmuxdSocket()).connect(d, 62078);
       const device = await new LockdowndClient(socket).getAllValues();
       socket.end();
+
+      // For network-connected devices, UniqueDeviceID may not be present in lockdownd response
+      // Use SerialNumber from usbmuxd device info as fallback (they are the same value)
+      if (!device.UniqueDeviceID && d.Properties && d.Properties.SerialNumber) {
+        device.UniqueDeviceID = d.Properties.SerialNumber;
+        debug(`Using SerialNumber as UniqueDeviceID for network device: ${device.UniqueDeviceID}`);
+      }
+
       return device;
     }),
   );


### PR DESCRIPTION
Fixes #295

This updates `getConnectedDevices()` to support listing iOS devices that are connected wirelessly by using `SerialNumber` for a device's `UniqueDeviceID` if not otherwise available.

I've tested this within a Capacitor project using `npx cap run ios`, and it's been working well for a few weeks. In order for this to work, the device needs to be paired in Finder with "Show this iPhone when on Wi-Fi" checked:

<img width="1984" height="1916" alt="image" src="https://github.com/user-attachments/assets/2ba0c0f8-65a6-4860-9419-63e96d47e4bb" />

If this doesn't work right away, make sure your device is unlocked and nearby. I had to reconnect my phone by cable a few times and force-restart Finder to get it to work the first time, but it eventually worked and has worked consistently since.