### PR TITLE
Support xcode27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.0.2](https://github.com/ionic-team/native-run/compare/v2.0.1...v2.0.2) (2026-01-07)
+
+
+### Bug Fixes
+
+* **android:** select available emulator port and improve emulator detection ([#399](https://github.com/ionic-team/native-run/issues/399)) ([45745fe](https://github.com/ionic-team/native-run/commit/45745fe2897c6cbded83bc735f66f910c0351018))
+
 ## [2.0.1](https://github.com/ionic-team/native-run/compare/v2.0.0...v2.0.1) (2024-01-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.0.3](https://github.com/ionic-team/native-run/compare/v2.0.2...v2.0.3) (2026-01-08)
+
+
+### Bug Fixes
+
+* Support wireless iOS devices ([#398](https://github.com/ionic-team/native-run/issues/398)) ([cf7a229](https://github.com/ionic-team/native-run/commit/cf7a2290d662d0dc087957a86b581d1447a6587e))
+
 ## [2.0.2](https://github.com/ionic-team/native-run/compare/v2.0.1...v2.0.2) (2026-01-07)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "native-run",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A CLI for running apps on iOS/Android devices and simulators/emulators",
   "bin": {
     "native-run": "bin/native-run"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "native-run",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A CLI for running apps on iOS/Android devices and simulators/emulators",
   "bin": {
     "native-run": "bin/native-run"


### PR DESCRIPTION
## Description
Added a check for xcode version before opening the simulator app. native-run will now correctly open DeviceHub on Xcode >= 27, and Simulator.app on Xcode < 27.

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation
- [ ] Other (CI, chores, etc.)

## Rationale / Problems Fixed
XCode 27 replaced the Simulator.app application with DeviceHub.app. The current version of native-run fails when running on a simulator with XCode27 because the Simulator.app no longer exists. I've added a simple check for xcode version so native-run can open the correct simulator application.

## Tests or Reproductions
Tested against my capacitor projects using xcode27. `npx ionic cap run ios`

## Screenshots / Media
<!--- (Optional) Include screenshots, videos or other files relevant to the pull request -->

## Platforms Affected
- [ ] Android
- [x] iOS
- [ ] Web

## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->
